### PR TITLE
feat(auth): implement register endpoint with bcrypt & JWT

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,0 +1,86 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConflictException, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { AuthService } from './auth.service';
+import { PrismaService } from '../prisma/prisma.service';
+import * as bcrypt from 'bcrypt';
+
+const mockPrisma = {
+  user: {
+    findUnique: jest.fn(),
+    create: jest.fn(),
+  },
+};
+
+const mockJwt = { sign: jest.fn().mockReturnValue('token') };
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: JwtService, useValue: mockJwt },
+      ],
+    }).compile();
+    service = module.get<AuthService>(AuthService);
+    jest.clearAllMocks();
+  });
+
+  describe('register', () => {
+    it('hashes password and returns user + access_token', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      mockPrisma.user.create.mockResolvedValue({
+        id: 'uuid',
+        email: 'a@b.com',
+        createdAt: new Date(),
+      });
+
+      const result = await service.register({ email: 'a@b.com', password: 'password123' });
+
+      expect(mockPrisma.user.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ email: 'a@b.com' }),
+        }),
+      );
+      const hash = mockPrisma.user.create.mock.calls[0][0].data.password;
+      expect(await bcrypt.compare('password123', hash)).toBe(true);
+      expect(result.access_token).toBe('token');
+    });
+
+    it('throws ConflictException if email already exists', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 'existing' });
+      await expect(
+        service.register({ email: 'a@b.com', password: 'password123' }),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('login', () => {
+    it('returns access_token for valid credentials', async () => {
+      const hash = await bcrypt.hash('password123', 10);
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 'uuid', email: 'a@b.com', password: hash });
+
+      const result = await service.login({ email: 'a@b.com', password: 'password123' });
+      expect(result.access_token).toBe('token');
+    });
+
+    it('throws UnauthorizedException for wrong password', async () => {
+      const hash = await bcrypt.hash('correct', 10);
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 'uuid', email: 'a@b.com', password: hash });
+
+      await expect(
+        service.login({ email: 'a@b.com', password: 'wrong' }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('throws UnauthorizedException if user not found', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      await expect(
+        service.login({ email: 'x@y.com', password: 'password123' }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the auth register and login endpoints as described in issue #1.

### Implementation

- `POST /api/v1/auth/register` — hashes password with bcrypt (cost factor 10), creates user, returns JWT + user object
- `POST /api/v1/auth/login` — validates credentials with bcrypt.compare, returns JWT
- `RegisterDto` / `LoginDto` with class-validator (`@IsEmail`, `@MinLength(8)`)
- `JwtStrategy` (passport-jwt) validates Bearer tokens on protected routes
- `JwtAuthGuard` extends `AuthGuard('jwt')` for route protection
- `AuthModule` wires `PassportModule`, `JwtModule` (7d expiry), service, controller, strategy

### Tests

Added `auth.service.spec.ts` with 5 unit tests:
- ✅ Hashes password with bcrypt on register
- ✅ Throws `ConflictException` on duplicate email
- ✅ Returns `access_token` on valid login
- ✅ Throws `UnauthorizedException` on wrong password
- ✅ Throws `UnauthorizedException` when user not found

All tests pass.

Closes #1