### PR TITLE
feat(wallet): implement POST /wallet with DTO validation

### DIFF
--- a/src/wallet/dto/wallet.dto.ts
+++ b/src/wallet/dto/wallet.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class UpsertWalletDto {
+  @IsString()
+  @IsNotEmpty()
+  publicKey: string;
+}

--- a/src/wallet/wallet.controller.ts
+++ b/src/wallet/wallet.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Post, Body, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { WalletService } from './wallet.service';
+import { UpsertWalletDto } from './dto/wallet.dto';
 
 @UseGuards(JwtAuthGuard)
 @Controller('wallet')
@@ -14,7 +15,7 @@ export class WalletController {
   }
 
   @Post()
-  upsert(@CurrentUser() user: any, @Body('publicKey') publicKey: string) {
-    return this.wallet.upsert(user.id, publicKey);
+  upsert(@CurrentUser() user: any, @Body() dto: UpsertWalletDto) {
+    return this.wallet.upsert(user.id, dto.publicKey);
   }
 }

--- a/src/wallet/wallet.service.ts
+++ b/src/wallet/wallet.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { StellarService } from '../stellar/stellar.service';
 
@@ -13,6 +13,7 @@ export class WalletService {
   }
 
   upsert(userId: string, publicKey: string) {
+    if (!publicKey) throw new BadRequestException('publicKey is required');
     return this.prisma.wallet.upsert({
       where: { userId },
       create: { userId, publicKey },


### PR DESCRIPTION
## Summary
Implements `POST /api/v1/wallet` to create or update a user's Stellar wallet public key.

## Changes
- **`src/wallet/dto/wallet.dto.ts`** — new `UpsertWalletDto` with `@IsString` + `@IsNotEmpty` on `publicKey`
- **`wallet.controller.ts`** — replaced raw `@Body('publicKey')` with `@Body() dto: UpsertWalletDto` for proper validation
- **`wallet.service.ts`** — added `BadRequestException` guard for missing `publicKey`

## Testing
- TypeScript compiles cleanly (`tsc --noEmit`)
- Global `ValidationPipe` (already configured in `main.ts`) handles invalid/missing body automatically

Closes #11