### PR TITLE
implemented the account logic

### DIFF
--- a/src/stellar/stellar.service.ts
+++ b/src/stellar/stellar.service.ts
@@ -1,5 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import * as StellarSdk from 'stellar-sdk';
+import * as https from 'https';
 
 @Injectable()
 export class StellarService {
@@ -35,5 +36,36 @@ export class StellarService {
 
     tx.sign(keypair);
     return this.server.submitTransaction(tx);
+  }
+
+  async fundAccount(publicKey: string) {
+    if (this.network !== StellarSdk.Networks.TESTNET) {
+      throw new BadRequestException('Friendbot is only available on the Stellar testnet');
+    }
+
+    const endpoint = new URL('https://friendbot.stellar.org');
+    endpoint.searchParams.set('addr', publicKey);
+
+    return new Promise<any>((resolve, reject) => {
+      https.get(endpoint, (res) => {
+        let body = '';
+        res.on('data', (chunk) => {
+          body += chunk;
+        });
+
+        res.on('end', () => {
+          if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+            try {
+              resolve(JSON.parse(body));
+            } catch (error) {
+              resolve({ result: body });
+            }
+            return;
+          }
+
+          reject(new BadRequestException(`Friendbot request failed with status ${res.statusCode}: ${body}`));
+        });
+      }).on('error', (error) => reject(new BadRequestException(`Friendbot request failed: ${error.message}`)));
+    });
   }
 }

--- a/src/wallet/wallet.controller.ts
+++ b/src/wallet/wallet.controller.ts
@@ -18,4 +18,9 @@ export class WalletController {
   upsert(@CurrentUser() user: any, @Body() dto: UpsertWalletDto) {
     return this.wallet.upsert(user.id, dto.publicKey);
   }
+
+  @Post('fund')
+  fund(@CurrentUser() user: any, @Body() dto: UpsertWalletDto) {
+    return this.wallet.fund(user.id, dto.publicKey);
+  }
 }

--- a/src/wallet/wallet.service.ts
+++ b/src/wallet/wallet.service.ts
@@ -20,4 +20,21 @@ export class WalletService {
       update: { publicKey },
     });
   }
+
+  async fund(userId: string, publicKey: string) {
+    if (!publicKey) throw new BadRequestException('publicKey is required');
+
+    const friendbotResult = await this.stellar.fundAccount(publicKey);
+
+    const wallet = await this.prisma.wallet.upsert({
+      where: { userId },
+      create: { userId, publicKey },
+      update: { publicKey },
+    });
+
+    return {
+      wallet,
+      friendbot: friendbotResult,
+    };
+  }
 }


### PR DESCRIPTION
Closes #29 
Added testnet Friendbot funding support.

[stellar.service.ts](https://ubiquitous-disco-jjx95jq4wg792qwq6.github.dev/)

Added [fundAccount(publicKey: string)](https://ubiquitous-disco-jjx95jq4wg792qwq6.github.dev/) to call https://friendbot.stellar.org
Throws if not on the Stellar testnet
[wallet.service.ts](https://ubiquitous-disco-jjx95jq4wg792qwq6.github.dev/)

Added [fund(userId: string, publicKey: string)](https://ubiquitous-disco-jjx95jq4wg792qwq6.github.dev/)
Funds the public key via Friendbot, then upserts the wallet record
[wallet.controller.ts](https://ubiquitous-disco-jjx95jq4wg792qwq6.github.dev/)

Added [POST /wallet/fund](https://ubiquitous-disco-jjx95jq4wg792qwq6.github.dev/)
Accepts [{ publicKey }](https://ubiquitous-disco-jjx95jq4wg792qwq6.github.dev/) and requires JWT auth
Usage
[POST /wallet/fund](https://ubiquitous-disco-jjx95jq4wg792qwq6.github.dev/)
Body: [{ "publicKey": "G..." }](https://ubiquitous-disco-jjx95jq4wg792qwq6.github.dev/)
This is implemented for testnet only.