### PR TITLE
feat(users): add soft-delete DELETE /users/me endpoint

### DIFF
--- a/prisma/migrations/20260518000000_add_user_soft_delete/migration.sql
+++ b/prisma/migrations/20260518000000_add_user_soft_delete/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "deletedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,6 +13,7 @@ model User {
   password         String
   refreshTokenHash String?
   createdAt        DateTime      @default(now())
+  deletedAt        DateTime?
   wallet           Wallet?
   sentTx           Transaction[] @relation("SentTransactions")
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Patch, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Patch, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { UsersService } from './users.service';
@@ -17,5 +17,11 @@ export class UsersController {
   @Patch('me')
   updateMe(@CurrentUser() user: any, @Body() dto: UpdateUserDto) {
     return this.users.update(user.id, dto);
+  }
+
+  @Delete('me')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  deleteMe(@CurrentUser() user: any) {
+    return this.users.softDelete(user.id);
   }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -31,4 +31,8 @@ export class UsersService {
       select: { id: true, email: true, createdAt: true },
     });
   }
+
+  softDelete(id: string) {
+    return this.prisma.user.update({ where: { id }, data: { deletedAt: new Date() } });
+  }
 }


### PR DESCRIPTION
## Summary

Implements soft-delete for user accounts via `DELETE /users/me`.

## Changes

- `prisma/schema.prisma`: Added `deletedAt DateTime?` field to `User` model
- `prisma/migrations/`: Migration to add `deletedAt` column to `User` table
- `UsersService.softDelete()`: Sets `deletedAt` to current timestamp
- `UsersController`: `DELETE /users/me` endpoint — requires JWT, returns 204 No Content

## Testing

All 14 existing tests pass. Build succeeds.

Closes #10