### PR TITLE
feat(wallet): implement GET /wallet/balance with tests

### DIFF
--- a/src/wallet/wallet.controller.spec.ts
+++ b/src/wallet/wallet.controller.spec.ts
@@ -1,0 +1,44 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WalletController } from './wallet.controller';
+import { WalletService } from './wallet.service';
+
+const mockWalletService = {
+  getBalance: jest.fn(),
+  upsert: jest.fn(),
+  fund: jest.fn(),
+};
+
+const user = { id: 'user-1', email: 'test@example.com' };
+
+describe('WalletController', () => {
+  let controller: WalletController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WalletController],
+      providers: [{ provide: WalletService, useValue: mockWalletService }],
+    }).compile();
+    controller = module.get<WalletController>(WalletController);
+    jest.clearAllMocks();
+  });
+
+  describe('GET /wallet/balance', () => {
+    it('returns balances for the current user', async () => {
+      const expected = { balances: [{ asset_type: 'native', balance: '100.0000000' }] };
+      mockWalletService.getBalance.mockResolvedValue(expected);
+
+      const result = await controller.balance(user as any);
+
+      expect(mockWalletService.getBalance).toHaveBeenCalledWith('user-1');
+      expect(result).toEqual(expected);
+    });
+
+    it('returns empty balances when user has no wallet', async () => {
+      mockWalletService.getBalance.mockResolvedValue({ balances: [] });
+
+      const result = await controller.balance(user as any);
+
+      expect(result).toEqual({ balances: [] });
+    });
+  });
+});

--- a/src/wallet/wallet.service.spec.ts
+++ b/src/wallet/wallet.service.spec.ts
@@ -1,0 +1,56 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { WalletService } from './wallet.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { StellarService } from '../stellar/stellar.service';
+
+const mockPrisma = {
+  wallet: {
+    findUnique: jest.fn(),
+    upsert: jest.fn(),
+  },
+};
+
+const mockStellar = {
+  getBalances: jest.fn(),
+  fundAccount: jest.fn(),
+};
+
+describe('WalletService', () => {
+  let service: WalletService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WalletService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: StellarService, useValue: mockStellar },
+      ],
+    }).compile();
+    service = module.get<WalletService>(WalletService);
+    jest.clearAllMocks();
+  });
+
+  describe('getBalance', () => {
+    it('returns empty balances when wallet not found', async () => {
+      mockPrisma.wallet.findUnique.mockResolvedValue(null);
+
+      const result = await service.getBalance('user-1');
+
+      expect(mockPrisma.wallet.findUnique).toHaveBeenCalledWith({ where: { userId: 'user-1' } });
+      expect(result).toEqual({ balances: [] });
+      expect(mockStellar.getBalances).not.toHaveBeenCalled();
+    });
+
+    it('returns balances from Stellar when wallet exists', async () => {
+      const publicKey = 'GABC123';
+      mockPrisma.wallet.findUnique.mockResolvedValue({ userId: 'user-1', publicKey });
+      mockStellar.getBalances.mockResolvedValue({ balances: [{ asset_type: 'native', balance: '100.0000000' }] });
+
+      const result = await service.getBalance('user-1');
+
+      expect(mockStellar.getBalances).toHaveBeenCalledWith(publicKey);
+      expect(result).toEqual({ balances: [{ asset_type: 'native', balance: '100.0000000' }] });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit tests for the `GET /wallet/balance` endpoint, completing the implementation required by issue #12.

The endpoint was already wired up in `WalletController` and `WalletService`; this PR adds the missing test coverage.

### Changes
- `wallet.service.spec.ts`: tests for `getBalance` — returns `{ balances: [] }` when no wallet exists, returns Stellar balances when wallet is found
- `wallet.controller.spec.ts`: tests that `balance()` delegates to `WalletService.getBalance` with the current user's id

### Tests
All 18 tests pass across 7 suites (`npm test`).

Closes #12