### PR TITLE
feat(wallet): validate Stellar public key format

### DIFF
--- a/src/wallet/dto/wallet.dto.ts
+++ b/src/wallet/dto/wallet.dto.ts
@@ -1,7 +1,22 @@
-import { IsString, IsNotEmpty } from 'class-validator';
+import { IsString, IsNotEmpty, Validate } from 'class-validator';
+import { ValidatorConstraint, ValidatorConstraintInterface, ValidationArguments } from 'class-validator';
+import { StrKey } from 'stellar-sdk';
+
+@ValidatorConstraint({ name: 'isStellarPublicKey', async: false })
+export class IsStellarPublicKeyConstraint implements ValidatorConstraintInterface {
+  validate(value: string, _args: ValidationArguments) {
+    if (typeof value !== 'string') return false;
+    return StrKey.isValidEd25519PublicKey(value);
+  }
+
+  defaultMessage(_args: ValidationArguments) {
+    return 'publicKey must be a valid Stellar public key (must start with "G" and be 56 characters)';
+  }
+}
 
 export class UpsertWalletDto {
   @IsString()
   @IsNotEmpty()
+  @Validate(IsStellarPublicKeyConstraint)
   publicKey: string;
 }


### PR DESCRIPTION
Closes #14

Reject invalid Stellar addresses on input by adding a custom class-validator constraint using stellar-sdk StrKey validation.