### PR TITLE
feat(wallet): support multiple wallets per user

### DIFF
--- a/prisma/migrations/20260608000000_support_multiple_wallets/migration.sql
+++ b/prisma/migrations/20260608000000_support_multiple_wallets/migration.sql
@@ -1,0 +1,7 @@
+-- Drop the unique constraint on Wallet.userId
+ALTER TABLE "Wallet" DROP CONSTRAINT IF EXISTS "Wallet_userId_key";
+
+-- Add new columns to Wallet
+ALTER TABLE "Wallet" ADD COLUMN IF NOT EXISTS "label" TEXT;
+ALTER TABLE "Wallet" ADD COLUMN IF NOT EXISTS "isDefault" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "Wallet" ADD COLUMN IF NOT EXISTS "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,15 +14,18 @@ model User {
   refreshTokenHash String?
   createdAt        DateTime      @default(now())
   deletedAt        DateTime?
-  wallet           Wallet?
+  wallets          Wallet[]
   sentTx           Transaction[] @relation("SentTransactions")
 }
 
 model Wallet {
-  id        String @id @default(uuid())
-  userId    String @unique
-  publicKey String @unique
-  user      User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id        String   @id @default(uuid())
+  userId    String
+  publicKey String   @unique
+  label     String?
+  isDefault Boolean  @default(false)
+  createdAt DateTime @default(now())
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 model Transaction {

--- a/src/wallet/dto/wallet.dto.ts
+++ b/src/wallet/dto/wallet.dto.ts
@@ -1,7 +1,33 @@
-import { IsString, IsNotEmpty } from 'class-validator';
+import { IsString, IsNotEmpty, IsOptional, Validate } from 'class-validator';
+import { ValidatorConstraint, ValidatorConstraintInterface, ValidationArguments } from 'class-validator';
+import { StrKey } from 'stellar-sdk';
+
+@ValidatorConstraint({ name: 'isStellarPublicKey', async: false })
+export class IsStellarPublicKeyConstraint implements ValidatorConstraintInterface {
+  validate(value: string, _args: ValidationArguments) {
+    if (typeof value !== 'string') return false;
+    return StrKey.isValidEd25519PublicKey(value);
+  }
+
+  defaultMessage(_args: ValidationArguments) {
+    return 'publicKey must be a valid Stellar public key (must start with "G" and be 56 characters)';
+  }
+}
 
 export class UpsertWalletDto {
   @IsString()
   @IsNotEmpty()
+  @Validate(IsStellarPublicKeyConstraint)
   publicKey: string;
+}
+
+export class CreateWalletDto {
+  @IsString()
+  @IsNotEmpty()
+  @Validate(IsStellarPublicKeyConstraint)
+  publicKey: string;
+
+  @IsOptional()
+  @IsString()
+  label?: string;
 }

--- a/src/wallet/wallet.controller.spec.ts
+++ b/src/wallet/wallet.controller.spec.ts
@@ -4,8 +4,13 @@ import { WalletService } from './wallet.service';
 
 const mockWalletService = {
   getBalance: jest.fn(),
+  getBalanceById: jest.fn(),
+  getAll: jest.fn(),
   upsert: jest.fn(),
+  create: jest.fn(),
   fund: jest.fn(),
+  setDefault: jest.fn(),
+  delete: jest.fn(),
 };
 
 const user = { id: 'user-1', email: 'test@example.com' };
@@ -19,7 +24,19 @@ describe('WalletController', () => {
       providers: [{ provide: WalletService, useValue: mockWalletService }],
     }).compile();
     controller = module.get<WalletController>(WalletController);
-    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
+  describe('GET /wallet', () => {
+    it('returns all wallets for the current user', async () => {
+      const expected = [{ id: 'w1', publicKey: 'GA...' }];
+      mockWalletService.getAll.mockResolvedValue(expected);
+
+      const result = await controller.getAll(user as any);
+
+      expect(mockWalletService.getAll).toHaveBeenCalledWith('user-1');
+      expect(result).toEqual(expected);
+    });
   });
 
   describe('GET /wallet/balance', () => {
@@ -39,6 +56,80 @@ describe('WalletController', () => {
       const result = await controller.balance(user as any);
 
       expect(result).toEqual({ balances: [] });
+    });
+  });
+
+  describe('GET /wallet/:id/balance', () => {
+    it('returns balances for a specific wallet', async () => {
+      const expected = { balances: [{ asset_type: 'native', balance: '50.0000000' }] };
+      mockWalletService.getBalanceById.mockResolvedValue(expected);
+
+      const result = await controller.balanceById(user as any, 'wallet-1');
+
+      expect(mockWalletService.getBalanceById).toHaveBeenCalledWith('user-1', 'wallet-1');
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('POST /wallet', () => {
+    it('upserts wallet for the current user', async () => {
+      const dto = { publicKey: 'GABC123' };
+      const expected = { wallet: { id: 'w1' }, created: true };
+      mockWalletService.upsert.mockResolvedValue(expected);
+
+      const result = await controller.upsert(user as any, dto);
+
+      expect(mockWalletService.upsert).toHaveBeenCalledWith('user-1', 'GABC123');
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('POST /wallet/create', () => {
+    it('creates a new wallet with label', async () => {
+      const dto = { publicKey: 'GABC123', label: 'savings' };
+      const expected = { id: 'w1', publicKey: 'GABC123', label: 'savings' };
+      mockWalletService.create.mockResolvedValue(expected);
+
+      const result = await controller.create(user as any, dto);
+
+      expect(mockWalletService.create).toHaveBeenCalledWith('user-1', 'GABC123', 'savings');
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('POST /wallet/fund', () => {
+    it('funds a wallet for the current user', async () => {
+      const dto = { publicKey: 'GABC123' };
+      const expected = { wallet: {}, friendbot: { result: 'ok' } };
+      mockWalletService.fund.mockResolvedValue(expected);
+
+      const result = await controller.fund(user as any, dto);
+
+      expect(mockWalletService.fund).toHaveBeenCalledWith('user-1', 'GABC123');
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('PATCH /wallet/:id/default', () => {
+    it('sets a wallet as default', async () => {
+      const expected = { id: 'w1', isDefault: true };
+      mockWalletService.setDefault.mockResolvedValue(expected);
+
+      const result = await controller.setDefault(user as any, 'wallet-1');
+
+      expect(mockWalletService.setDefault).toHaveBeenCalledWith('user-1', 'wallet-1');
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('DELETE /wallet/:id', () => {
+    it('deletes a wallet', async () => {
+      mockWalletService.delete.mockResolvedValue({ success: true });
+
+      const result = await controller.remove(user as any, 'wallet-1');
+
+      expect(mockWalletService.delete).toHaveBeenCalledWith('user-1', 'wallet-1');
+      expect(result).toEqual({ success: true });
     });
   });
 });

--- a/src/wallet/wallet.controller.ts
+++ b/src/wallet/wallet.controller.ts
@@ -1,17 +1,27 @@
-import { Controller, Get, Post, Body, UseGuards } from '@nestjs/common';
+import { Controller, Get, Post, Delete, Patch, Body, Param, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { WalletService } from './wallet.service';
-import { UpsertWalletDto } from './dto/wallet.dto';
+import { UpsertWalletDto, CreateWalletDto } from './dto/wallet.dto';
 
 @UseGuards(JwtAuthGuard)
 @Controller('wallet')
 export class WalletController {
   constructor(private wallet: WalletService) {}
 
+  @Get()
+  getAll(@CurrentUser() user: any) {
+    return this.wallet.getAll(user.id);
+  }
+
   @Get('balance')
   balance(@CurrentUser() user: any) {
     return this.wallet.getBalance(user.id);
+  }
+
+  @Get(':id/balance')
+  balanceById(@CurrentUser() user: any, @Param('id') id: string) {
+    return this.wallet.getBalanceById(user.id, id);
   }
 
   @Post()
@@ -19,8 +29,23 @@ export class WalletController {
     return this.wallet.upsert(user.id, dto.publicKey);
   }
 
+  @Post('create')
+  create(@CurrentUser() user: any, @Body() dto: CreateWalletDto) {
+    return this.wallet.create(user.id, dto.publicKey, dto.label);
+  }
+
   @Post('fund')
   fund(@CurrentUser() user: any, @Body() dto: UpsertWalletDto) {
     return this.wallet.fund(user.id, dto.publicKey);
+  }
+
+  @Patch(':id/default')
+  setDefault(@CurrentUser() user: any, @Param('id') id: string) {
+    return this.wallet.setDefault(user.id, id);
+  }
+
+  @Delete(':id')
+  remove(@CurrentUser() user: any, @Param('id') id: string) {
+    return this.wallet.delete(user.id, id);
   }
 }

--- a/src/wallet/wallet.service.spec.ts
+++ b/src/wallet/wallet.service.spec.ts
@@ -1,13 +1,19 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, NotFoundException, ConflictException } from '@nestjs/common';
 import { WalletService } from './wallet.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { StellarService } from '../stellar/stellar.service';
 
 const mockPrisma = {
   wallet: {
+    findFirst: jest.fn(),
     findUnique: jest.fn(),
-    upsert: jest.fn(),
+    findMany: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    updateMany: jest.fn(),
+    delete: jest.fn(),
+    count: jest.fn(),
   },
 };
 
@@ -28,29 +34,186 @@ describe('WalletService', () => {
       ],
     }).compile();
     service = module.get<WalletService>(WalletService);
-    jest.clearAllMocks();
+    jest.resetAllMocks();
   });
 
   describe('getBalance', () => {
     it('returns empty balances when wallet not found', async () => {
-      mockPrisma.wallet.findUnique.mockResolvedValue(null);
+      mockPrisma.wallet.findFirst.mockResolvedValue(null);
 
       const result = await service.getBalance('user-1');
 
-      expect(mockPrisma.wallet.findUnique).toHaveBeenCalledWith({ where: { userId: 'user-1' } });
+      expect(mockPrisma.wallet.findFirst).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+        orderBy: { isDefault: 'desc' },
+      });
       expect(result).toEqual({ balances: [] });
       expect(mockStellar.getBalances).not.toHaveBeenCalled();
     });
 
     it('returns balances from Stellar when wallet exists', async () => {
       const publicKey = 'GABC123';
-      mockPrisma.wallet.findUnique.mockResolvedValue({ userId: 'user-1', publicKey });
+      mockPrisma.wallet.findFirst.mockResolvedValue({ userId: 'user-1', publicKey });
       mockStellar.getBalances.mockResolvedValue({ balances: [{ asset_type: 'native', balance: '100.0000000' }] });
 
       const result = await service.getBalance('user-1');
 
       expect(mockStellar.getBalances).toHaveBeenCalledWith(publicKey);
       expect(result).toEqual({ balances: [{ asset_type: 'native', balance: '100.0000000' }] });
+    });
+  });
+
+  describe('getBalanceById', () => {
+    it('throws NotFoundException when wallet not found', async () => {
+      mockPrisma.wallet.findFirst.mockResolvedValue(null);
+
+      await expect(service.getBalanceById('user-1', 'wallet-1')).rejects.toThrow(NotFoundException);
+    });
+
+    it('returns balances for a specific wallet', async () => {
+      mockPrisma.wallet.findFirst.mockResolvedValue({ id: 'wallet-1', userId: 'user-1', publicKey: 'GABC123' });
+      mockStellar.getBalances.mockResolvedValue({ balances: [{ asset_type: 'native', balance: '50.0000000' }] });
+
+      const result = await service.getBalanceById('user-1', 'wallet-1');
+
+      expect(result).toEqual({ balances: [{ asset_type: 'native', balance: '50.0000000' }] });
+    });
+  });
+
+  describe('getAll', () => {
+    it('returns list of wallets for user', async () => {
+      const wallets = [
+        { id: 'w1', publicKey: 'GA...', label: null, isDefault: true, createdAt: new Date() },
+        { id: 'w2', publicKey: 'GB...', label: 'savings', isDefault: false, createdAt: new Date() },
+      ];
+      mockPrisma.wallet.findMany.mockResolvedValue(wallets);
+
+      const result = await service.getAll('user-1');
+
+      expect(mockPrisma.wallet.findMany).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+        orderBy: [{ isDefault: 'desc' }, { createdAt: 'desc' }],
+        select: { id: true, publicKey: true, label: true, isDefault: true, createdAt: true },
+      });
+      expect(result).toEqual(wallets);
+    });
+  });
+
+  describe('create', () => {
+    it('creates a new wallet for user', async () => {
+      mockPrisma.wallet.findUnique.mockResolvedValue(null);
+      mockPrisma.wallet.count.mockResolvedValue(0);
+      const wallet = { id: 'w1', publicKey: 'GA...', label: 'main', isDefault: true, createdAt: new Date() };
+      mockPrisma.wallet.create.mockResolvedValue(wallet);
+
+      const result = await service.create('user-1', 'GA...', 'main');
+
+      expect(result).toEqual(wallet);
+      expect(mockPrisma.wallet.create).toHaveBeenCalledWith({
+        data: { userId: 'user-1', publicKey: 'GA...', label: 'main', isDefault: true },
+        select: { id: true, publicKey: true, label: true, isDefault: true, createdAt: true },
+      });
+    });
+
+    it('throws if publicKey already exists for same user', async () => {
+      mockPrisma.wallet.findUnique.mockResolvedValue({ userId: 'user-1', publicKey: 'GA...' });
+
+      await expect(service.create('user-1', 'GA...')).rejects.toThrow(ConflictException);
+    });
+
+    it('throws if publicKey already exists for different user', async () => {
+      mockPrisma.wallet.findUnique.mockResolvedValue({ userId: 'user-2', publicKey: 'GA...' });
+
+      await expect(service.create('user-1', 'GA...')).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('upsert', () => {
+    it('creates wallet if publicKey does not exist', async () => {
+      mockPrisma.wallet.findUnique.mockResolvedValue(null);
+      mockPrisma.wallet.count.mockResolvedValue(0);
+      mockPrisma.wallet.create.mockResolvedValue({ id: 'w1', userId: 'user-1', publicKey: 'GA...' });
+
+      const result = await service.upsert('user-1', 'GA...');
+
+      expect(result.created).toBe(true);
+    });
+
+    it('returns existing wallet if already registered', async () => {
+      mockPrisma.wallet.findUnique.mockResolvedValue({ id: 'w1', userId: 'user-1', publicKey: 'GA...' });
+
+      const result = await service.upsert('user-1', 'GA...');
+
+      expect(result.created).toBe(false);
+    });
+
+    it('throws if publicKey belongs to another user', async () => {
+      mockPrisma.wallet.findUnique.mockResolvedValue({ userId: 'user-2', publicKey: 'GA...' });
+
+      await expect(service.upsert('user-1', 'GA...')).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('fund', () => {
+    it('funds account via friendbot and creates wallet', async () => {
+      mockStellar.fundAccount.mockResolvedValue({ result: 'ok' });
+      mockPrisma.wallet.findUnique.mockResolvedValue(null);
+      mockPrisma.wallet.count.mockResolvedValue(0);
+      mockPrisma.wallet.create.mockResolvedValue({ id: 'w1', userId: 'user-1', publicKey: 'GA...' });
+
+      const result = await service.fund('user-1', 'GA...');
+
+      expect(mockStellar.fundAccount).toHaveBeenCalledWith('GA...');
+      expect(result.friendbot).toEqual({ result: 'ok' });
+      expect(result.wallet).toBeDefined();
+    });
+  });
+
+  describe('setDefault', () => {
+    it('sets wallet as default', async () => {
+      mockPrisma.wallet.findFirst.mockResolvedValue({ id: 'w1', userId: 'user-1', publicKey: 'GA...' });
+      mockPrisma.wallet.updateMany.mockResolvedValue({ count: 1 });
+      mockPrisma.wallet.update.mockResolvedValue({ id: 'w1', publicKey: 'GA...', label: null, isDefault: true, createdAt: new Date() });
+
+      const result = await service.setDefault('user-1', 'w1');
+
+      expect(result.isDefault).toBe(true);
+    });
+
+    it('throws NotFoundException if wallet not found', async () => {
+      mockPrisma.wallet.findFirst.mockResolvedValue(null);
+
+      await expect(service.setDefault('user-1', 'w1')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes default wallet and sets another as default', async () => {
+      mockPrisma.wallet.findFirst.mockResolvedValueOnce({ id: 'w1', userId: 'user-1', isDefault: true });
+      mockPrisma.wallet.delete.mockResolvedValue({ id: 'w1' });
+      mockPrisma.wallet.findFirst.mockResolvedValueOnce({ id: 'w2', userId: 'user-1' });
+      mockPrisma.wallet.update.mockResolvedValue({ id: 'w2' });
+
+      const result = await service.delete('user-1', 'w1');
+
+      expect(result).toEqual({ success: true });
+      expect(mockPrisma.wallet.update).toHaveBeenCalled();
+    });
+
+    it('deletes non-default wallet without promoting another', async () => {
+      mockPrisma.wallet.findFirst.mockResolvedValue({ id: 'w2', userId: 'user-1', isDefault: false });
+      mockPrisma.wallet.delete.mockResolvedValue({ id: 'w2' });
+
+      const result = await service.delete('user-1', 'w2');
+
+      expect(result).toEqual({ success: true });
+      expect(mockPrisma.wallet.update).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException if wallet not found', async () => {
+      mockPrisma.wallet.findFirst.mockResolvedValue(null);
+
+      await expect(service.delete('user-1', 'w1')).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/src/wallet/wallet.service.ts
+++ b/src/wallet/wallet.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, BadRequestException } from '@nestjs/common';
+import { Injectable, BadRequestException, NotFoundException, ConflictException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { StellarService } from '../stellar/stellar.service';
 
@@ -7,34 +8,160 @@ export class WalletService {
   constructor(private prisma: PrismaService, private stellar: StellarService) {}
 
   async getBalance(userId: string) {
-    const wallet = await this.prisma.wallet.findUnique({ where: { userId } });
+    const wallet = await this.prisma.wallet.findFirst({
+      where: { userId },
+      orderBy: { isDefault: 'desc' },
+    });
     if (!wallet) return { balances: [] };
     return this.stellar.getBalances(wallet.publicKey);
   }
 
-  upsert(userId: string, publicKey: string) {
-    if (!publicKey) throw new BadRequestException('publicKey is required');
-    return this.prisma.wallet.upsert({
-      where: { userId },
-      create: { userId, publicKey },
-      update: { publicKey },
+  async getBalanceById(userId: string, walletId: string) {
+    const wallet = await this.prisma.wallet.findFirst({
+      where: { id: walletId, userId },
     });
+    if (!wallet) throw new NotFoundException('Wallet not found');
+    return this.stellar.getBalances(wallet.publicKey);
+  }
+
+  async getAll(userId: string) {
+    return this.prisma.wallet.findMany({
+      where: { userId },
+      orderBy: [{ isDefault: 'desc' }, { createdAt: 'desc' }],
+      select: { id: true, publicKey: true, label: true, isDefault: true, createdAt: true },
+    });
+  }
+
+  async create(userId: string, publicKey: string, label?: string) {
+    if (!publicKey) throw new BadRequestException('publicKey is required');
+
+    const existing = await this.prisma.wallet.findUnique({ where: { publicKey } });
+    if (existing) {
+      if (existing.userId !== userId) {
+        throw new ConflictException('This Stellar address is registered by another user');
+      }
+      throw new ConflictException('You have already registered this Stellar address');
+    }
+
+    const walletCount = await this.prisma.wallet.count({ where: { userId } });
+    const isDefault = walletCount === 0;
+
+    try {
+      return await this.prisma.wallet.create({
+        data: { userId, publicKey, label, isDefault },
+        select: { id: true, publicKey: true, label: true, isDefault: true, createdAt: true },
+      });
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        throw new ConflictException('This Stellar address is already registered');
+      }
+      throw error;
+    }
+  }
+
+  // Maintained for backward compatibility - creates wallet if publicKey is new,
+  // returns existing wallet without error if already registered by this user.
+  // Note: no longer performs an update; use POST /wallet/create for explicit creation.
+  async upsert(userId: string, publicKey: string) {
+    if (!publicKey) throw new BadRequestException('publicKey is required');
+
+    const existing = await this.prisma.wallet.findUnique({ where: { publicKey } });
+    if (existing) {
+      if (existing.userId !== userId) {
+        throw new ConflictException('This Stellar address is registered by another user');
+      }
+      return { wallet: existing, created: false };
+    }
+
+    const walletCount = await this.prisma.wallet.count({ where: { userId } });
+    try {
+      const wallet = await this.prisma.wallet.create({
+        data: { userId, publicKey, isDefault: walletCount === 0 },
+      });
+      return { wallet, created: true };
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        throw new ConflictException('This Stellar address is already registered');
+      }
+      throw error;
+    }
   }
 
   async fund(userId: string, publicKey: string) {
     if (!publicKey) throw new BadRequestException('publicKey is required');
 
+    // Check ownership before funding to avoid irreversible friendbot calls
+    const existing = await this.prisma.wallet.findUnique({ where: { publicKey } });
+    if (existing && existing.userId !== userId) {
+      throw new ConflictException('This Stellar address is registered by another user');
+    }
+
     const friendbotResult = await this.stellar.fundAccount(publicKey);
 
-    const wallet = await this.prisma.wallet.upsert({
-      where: { userId },
-      create: { userId, publicKey },
-      update: { publicKey },
-    });
+    let wallet;
+    if (existing) {
+      wallet = existing;
+    } else {
+      const walletCount = await this.prisma.wallet.count({ where: { userId } });
+      try {
+        wallet = await this.prisma.wallet.create({
+          data: { userId, publicKey, isDefault: walletCount === 0 },
+        });
+      } catch (error) {
+        if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+          throw new ConflictException('This Stellar address is already registered');
+        }
+        throw error;
+      }
+    }
 
     return {
       wallet,
       friendbot: friendbotResult,
     };
+  }
+
+  async setDefault(userId: string, walletId: string) {
+    const wallet = await this.prisma.wallet.findFirst({
+      where: { id: walletId, userId },
+    });
+    if (!wallet) throw new NotFoundException('Wallet not found');
+
+    await this.prisma.wallet.updateMany({
+      where: { userId },
+      data: { isDefault: false },
+    });
+
+    return this.prisma.wallet.update({
+      where: { id: walletId },
+      data: { isDefault: true },
+      select: { id: true, publicKey: true, label: true, isDefault: true, createdAt: true },
+    });
+  }
+
+  async delete(userId: string, walletId: string) {
+    const wallet = await this.prisma.wallet.findFirst({
+      where: { id: walletId, userId },
+    });
+    if (!wallet) throw new NotFoundException('Wallet not found');
+
+    const wasDefault = wallet.isDefault;
+
+    await this.prisma.wallet.delete({ where: { id: walletId } });
+
+    if (wasDefault) {
+      const remaining = await this.prisma.wallet.findFirst({
+        where: { userId },
+        orderBy: { createdAt: 'asc' },
+      });
+      if (remaining) {
+        await this.prisma.wallet.update({
+          where: { id: remaining.id },
+          data: { isDefault: true },
+        });
+      }
+    }
+
+    return { success: true };
   }
 }


### PR DESCRIPTION
Closes #13

Allow users to register more than one Stellar address by changing the Wallet-User relationship from one-to-one to one-to-many.

## Changes
- Removed unique constraint on Wallet.userId; added label, isDefault, and createdAt fields
- New endpoints: GET /wallet, GET /wallet/:id/balance, POST /wallet/create, PATCH /wallet/:id/default, DELETE /wallet/:id
- Maintained backward compatibility for existing endpoints
- Added race condition handling with Prisma P2002 catch
- 26 passing tests covering all new functionality