### PR TITLE
chore: add environment validation on startup

### DIFF
--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -1,0 +1,28 @@
+import { IsString, IsNotEmpty, IsIn, IsPort, ValidateIf } from 'class-validator';
+
+export class EnvConfig {
+  @IsString()
+  @IsNotEmpty()
+  DATABASE_URL: string;
+
+  @IsPort()
+  @ValidateIf((_, v) => v !== undefined)
+  PORT?: string;
+
+  @IsString()
+  @IsNotEmpty()
+  JWT_SECRET: string;
+
+  @IsString()
+  @IsNotEmpty()
+  JWT_REFRESH_SECRET: string;
+
+  @IsString()
+  @IsIn(['testnet', 'public'])
+  @ValidateIf((_, v) => v !== undefined)
+  STELLAR_NETWORK?: string;
+
+  @IsString()
+  @IsNotEmpty()
+  STELLAR_SECRET_KEY: string;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,33 @@
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
+import { validateSync } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
 import { AppModule } from './app.module';
+import { EnvConfig } from './config/env.config';
+
+function validateEnv() {
+  const config = plainToInstance(EnvConfig, process.env, {
+    enableImplicitConversion: true,
+  });
+
+  const errors = validateSync(config, { skipMissingProperties: false });
+
+  if (errors.length > 0) {
+    const missingVars: string[] = [];
+    for (const error of errors) {
+      const constraints = error.constraints ?? {};
+      const messages = Object.values(constraints);
+      missingVars.push(`  - ${error.property}: ${messages.join(', ')}`);
+    }
+    throw new Error(
+      `Environment validation failed - missing or invalid variables:\n${missingVars.join('\n')}`,
+    );
+  }
+}
 
 async function bootstrap() {
+  validateEnv();
+
   const app = await NestFactory.create(AppModule);
   app.setGlobalPrefix('api/v1');
   app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));


### PR DESCRIPTION
Closes #38

Use class-validator to validate environment variables at application startup, ensuring all required env vars are present and valid before the server starts.