### PR TITLE
feat(transactions): implement POST /transactions with DTO validation

### DIFF
--- a/src/transactions/dto/create-transaction.dto.ts
+++ b/src/transactions/dto/create-transaction.dto.ts
@@ -1,0 +1,20 @@
+import { IsString, IsNotEmpty, IsNumber, IsOptional, Min, IsIn, Validate } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsStellarPublicKeyConstraint } from '../../wallet/dto/wallet.dto';
+
+export class CreateTransactionDto {
+  @IsString()
+  @IsNotEmpty()
+  @Validate(IsStellarPublicKeyConstraint)
+  recipient: string;
+
+  @IsNumber()
+  @Min(0.0000001)
+  @Type(() => Number)
+  amount: number;
+
+  @IsOptional()
+  @IsString()
+  @IsIn(['XLM'])
+  asset?: string;
+}

--- a/src/transactions/transactions.controller.ts
+++ b/src/transactions/transactions.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Post, Body, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { TransactionsService } from './transactions.service';
+import { CreateTransactionDto } from './dto/create-transaction.dto';
 
 @UseGuards(JwtAuthGuard)
 @Controller('transactions')
@@ -11,11 +12,9 @@ export class TransactionsController {
   @Post()
   create(
     @CurrentUser() user: any,
-    @Body('recipient') recipient: string,
-    @Body('amount') amount: number,
-    @Body('asset') asset: string,
+    @Body() dto: CreateTransactionDto,
   ) {
-    return this.tx.create(user.id, recipient, amount, asset);
+    return this.tx.create(user.id, dto.recipient, dto.amount, dto.asset);
   }
 
   @Get()

--- a/src/transactions/transactions.module.ts
+++ b/src/transactions/transactions.module.ts
@@ -1,6 +1,11 @@
 import { Module } from '@nestjs/common';
 import { TransactionsService } from './transactions.service';
 import { TransactionsController } from './transactions.controller';
+import { PrismaModule } from '../prisma/prisma.module';
 
-@Module({ providers: [TransactionsService], controllers: [TransactionsController] })
+@Module({
+  imports: [PrismaModule],
+  providers: [TransactionsService],
+  controllers: [TransactionsController],
+})
 export class TransactionsModule {}


### PR DESCRIPTION
## Summary

Implements the POST /transactions endpoint with proper DTO validation.

### Changes
- Created `CreateTransactionDto` with `class-validator` decorators:
  - `recipient`: required, validated as Stellar public key
  - `amount`: required, minimum 0.0000001
  - `asset`: optional, restricted to "XLM"
- Updated `TransactionsController` to accept `@Body() dto: CreateTransactionDto`
- Added explicit `PrismaModule` import to `TransactionsModule`

Closes #16